### PR TITLE
Fixes boost 1.73/1.74 and deque related compilation errors

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -27,6 +27,7 @@
 #include <event2/bufferevent.h>
 #include <event2/util.h>
 #include <event2/keyvalq_struct.h>
+#include <deque>
 
 #include "support/events.h"
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -68,6 +68,10 @@
 #include <QUrlQuery>
 #endif
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MAC)
         "macosx"

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -31,6 +31,10 @@
 #include <QDebug>
 #include <QTimer>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -26,6 +26,10 @@
 #include <QDesktopWidget>
 #include <QPainter>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -25,6 +25,10 @@
 #include <QIcon>
 #include <QList>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -35,6 +35,10 @@
 #include <QSet>
 #include <QTimer>
 
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -59,6 +59,9 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/thread.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 #if defined(NDEBUG)
 # error "Kyan Core cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -15,6 +15,9 @@
 #include <atomic>
 
 #include <boost/signals2/signal.hpp>
+// Fixing Boost 1.73 compile errors
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;


### PR DESCRIPTION
Adds missing header file for deque and fixes boost 1.73/1.74 compilation errors as commit in [here](https://github.com/RavenProject/Ravencoin/pull/816) 