### PR TITLE
Masternode reward share ratio gradual change

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,85 +47,121 @@ Rewards Table
 10% of the block reward will be sent as superblocks at every block for the Governance.
 
 <table border=0 cellpadding=0 cellspacing=0 width=701 class=xl6553517252
- style='border-collapse:collapse;table-layout:fixed;width:528pt'>
- <col class=xl6553517252 width=139 style='mso-width-source:userset;mso-width-alt:
- 4785;width:104pt'>
- <col class=xl6553517252 width=107 span=2 style='mso-width-source:userset;
- mso-width-alt:3702;width:81pt'>
- <col class=xl6553517252 width=134 style='mso-width-source:userset;mso-width-alt:
- 4608;width:100pt'>
- <col class=xl6553517252 width=107 span=2 style='mso-width-source:userset;
- mso-width-alt:3702;width:81pt'>
- <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6317252 width=150 style='height:15.75pt;width:104pt'>Block</td>
-  <td class=xl6317252 width=107 style='width:81pt'>Collateral</td>
-  <td class=xl6317252 width=107 style='width:81pt'>Block Reward</td>
-  <td class=xl6317252 width=107 style='width:81pt'>MN Reward %</td>
-  <td class=xl6317252 width=134 style='width:100pt'>Mining Reward %</td>
-  <td class=xl6317252 width=107 style='width:81pt'>MN Reward</td>
-  <td class=xl6317252 width=107 style='width:81pt'>Mining Reward</td>
- </tr>
- <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>18-20000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>2250</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>1012.5</td>
-  <td class=xl6817252 align=right>1012.5</td>
- </tr>
-   <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>20001-40000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>2000</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>900</td>
-  <td class=xl6817252 align=right>900</td>
- </tr>
-    <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>40001-60000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>1750</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>787.5</td>
-  <td class=xl6817252 align=right>787.5</td>
- </tr>
-     <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>60001-80000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>1500</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>675</td>
-  <td class=xl6817252 align=right>675</td>
- </tr>
-     <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>80001-100000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>1250</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>562.5</td>
-  <td class=xl6817252 align=right>562.5</td>
- </tr>
-     <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>100001-120000</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>1125</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>506.25</td>
-  <td class=xl6817252 align=right>506.25</td>
- </tr>
- <tr height=21 style='mso-height-source:userset;height:15.75pt'>
-  <td height=21 class=xl6417252 style='height:15.75pt'>120001+</td>
-  <td class=xl6517252>200000</td>
-  <td class=xl6617252>1000</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6617252>45</td>
-  <td class=xl6717252 align=right>450</td>
-  <td class=xl6817252 align=right>450</td>
- </tr>
- </table>
+style='border-collapse:collapse;table-layout:fixed;width:528pt'>
+	<col class=xl6553517252 width=139 style='mso-width-source:userset;mso-width-alt:
+	4785;width:104pt'>
+	<col class=xl6553517252 width=107 span=2 style='mso-width-source:userset;
+	mso-width-alt:3702;width:81pt'>
+	<col class=xl6553517252 width=134 style='mso-width-source:userset;mso-width-alt:
+	4608;width:100pt'>
+	<col class=xl6553517252 width=107 span=2 style='mso-width-source:userset;
+	mso-width-alt:3702;width:81pt'>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6317252 width=150 style='height:15.75pt;width:104pt'>Block</td>
+		<td class=xl6317252 width=107 style='width:81pt'>Collateral</td>
+		<td class=xl6317252 width=107 style='width:81pt'>Block Reward</td>
+		<td class=xl6317252 width=107 style='width:81pt'>MN Reward %</td>
+		<td class=xl6317252 width=134 style='width:100pt'>Mining Reward %</td>
+		<td class=xl6317252 width=107 style='width:81pt'>MN Reward</td>
+		<td class=xl6317252 width=107 style='width:81pt'>Mining Reward</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>18-20000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>2250</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6717252 align=right>1012.5</td>
+		<td class=xl6817252 align=right>1012.5</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>20001-40000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>2000</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6717252 align=right>900</td>
+		<td class=xl6817252 align=right>900</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>40001-60000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1750</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6717252 align=right>787.5</td>
+		<td class=xl6817252 align=right>787.5</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>60001-80000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1500</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6617252>45</td>
+		<td class=xl6717252 align=right>675</td>
+		<td class=xl6817252 align=right>675</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>80001-82016</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1250</td>
+		<td class=xl6617252>58</td>
+		<td class=xl6617252>42</td>
+		<td class=xl6717252 align=right>725</td>
+		<td class=xl6817252 align=right>525</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>82017-84032</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1250</td>
+		<td class=xl6617252>66</td>
+		<td class=xl6617252>34</td>
+		<td class=xl6717252 align=right>825</td>
+		<td class=xl6817252 align=right>425</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>84033-86048</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1250</td>
+		<td class=xl6617252>74</td>
+		<td class=xl6617252>26</td>
+		<td class=xl6717252 align=right>925</td>
+		<td class=xl6817252 align=right>325</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>86049-88066</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1250</td>
+		<td class=xl6617252>82</td>
+		<td class=xl6617252>18</td>
+		<td class=xl6717252 align=right>1025</td>
+		<td class=xl6817252 align=right>225</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>88067-100000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1250</td>
+		<td class=xl6617252>90</td>
+		<td class=xl6617252>10</td>
+		<td class=xl6717252 align=right>1125</td>
+		<td class=xl6817252 align=right>125</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>100001-120000</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1125</td>
+		<td class=xl6617252>90</td>
+		<td class=xl6617252>10</td>
+		<td class=xl6717252 align=right>1012.5</td>
+		<td class=xl6817252 align=right>112.5</td>
+	</tr>
+	<tr height=21 style='mso-height-source:userset;height:15.75pt'>
+		<td height=21 class=xl6417252 style='height:15.75pt'>120001+</td>
+		<td class=xl6517252>200000</td>
+		<td class=xl6617252>1000</td>
+		<td class=xl6617252>90</td>
+		<td class=xl6617252>10</td>
+		<td class=xl6717252 align=right>900</td>
+		<td class=xl6817252 align=right>100</td>
+	</tr>
+</table>

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -235,8 +235,8 @@ public:
         strNetworkID = "main";
         //consensus.nSubsidyHalvingInterval = 210240; // Note: actual number of blocks per calendar year with DGW v3 is ~200700 (for example 449750 - 249050)
         consensus.nMasternodePaymentsStartBlock = 1; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
-        consensus.nMasternodePaymentsIncreaseBlock = 2; // actual historical value
-        consensus.nMasternodePaymentsIncreasePeriod = 576*30; // 17280 - actual historical value
+        consensus.nMasternodePaymentsIncreaseBlock = 80000; // actual historical value
+        consensus.nMasternodePaymentsIncreasePeriod = 2016; // 3.5 days
         consensus.nInstantSendConfirmationsRequired = 6;
         consensus.nInstantSendKeepLock = 24;
         consensus.nBudgetPaymentsStartBlock = 1; // actual historical value

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1062,19 +1062,19 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
 		return blockValue * (50 / 100); // Until block 80000 reached, masternode payments for Kyanite will be 50% of the block reward.
 
 	if (nHeight < nMNPIBlock + (nMNPIPeriod * 1)) 
-		return blockValue * (58 / 100); // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
+		return blockValue * (58 / 100); // Block: 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
 
     if (nHeight < nMNPIBlock + (nMNPIPeriod * 2)) 
-		return blockValue * (66 / 100); // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
+		return blockValue * (66 / 100); // Block: 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
 
     if (nHeight < nMNPIBlock + (nMNPIPeriod * 3)) 
-		return blockValue * (74 / 100); // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
+		return blockValue * (74 / 100); // Block: 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
 
     if (nHeight < nMNPIBlock + (nMNPIPeriod * 4)) 
-		return blockValue * (82 / 100); // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
+		return blockValue * (82 / 100); // Block: 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
 
     if (nHeight < nMNPIBlock + (nMNPIPeriod * 5)) 
-		return blockValue * (90 / 100); // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
+		return blockValue * (90 / 100); // Block: 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
 }
 
 bool IsInitialBlockDownload()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1055,19 +1055,26 @@ CAmount GetBlockSubsidy(int nPrevBits, int nPrevHeight, const Consensus::Params&
 
 CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
 {
-    CAmount ret = blockValue / 2; // Until block 80000 reached, masternode payments for Kyanite will be 50% of the block reward.
-
     int nMNPIBlock = Params().GetConsensus().nMasternodePaymentsIncreaseBlock; // Block 80000 - Approximately 2021-02-02 7:30  UTC
     int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod; // 2016 blocks - 3.5 days
-	int rewardIncreasePercent = 8 / 100;
 
-	if (nHeight > nMNPIBlock + (nMNPIPeriod * 0)) ret += blockValue * rewardIncreasePercent; // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 1)) ret += blockValue * rewardIncreasePercent; // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 2)) ret += blockValue * rewardIncreasePercent; // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 3)) ret += blockValue * rewardIncreasePercent; // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 4)) ret += blockValue * rewardIncreasePercent; // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
+	if (nHeight < nMNPIBlock)
+		return blockValue * (50 / 100); // Until block 80000 reached, masternode payments for Kyanite will be 50% of the block reward.
 
-   return ret;
+	if (nHeight < nMNPIBlock + (nMNPIPeriod * 1)) 
+		return blockValue * (58 / 100); // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
+
+    if (nHeight < nMNPIBlock + (nMNPIPeriod * 2)) 
+		return blockValue * (66 / 100); // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
+
+    if (nHeight < nMNPIBlock + (nMNPIPeriod * 3)) 
+		return blockValue * (74 / 100); // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
+
+    if (nHeight < nMNPIBlock + (nMNPIPeriod * 4)) 
+		return blockValue * (82 / 100); // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
+
+    if (nHeight < nMNPIBlock + (nMNPIPeriod * 5)) 
+		return blockValue * (90 / 100); // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
 }
 
 bool IsInitialBlockDownload()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1073,8 +1073,7 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
     if (nHeight < nMNPIBlock + (nMNPIPeriod * 4)) 
 		return blockValue * (82 / 100); // Block: 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
 
-    if (nHeight < nMNPIBlock + (nMNPIPeriod * 5)) 
-		return blockValue * (90 / 100); // Block: 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
+	return blockValue * (90 / 100); // Block: 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
 }
 
 bool IsInitialBlockDownload()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1048,100 +1048,55 @@ CAmount GetBlockSubsidy(int nPrevBits, int nPrevHeight, const Consensus::Params&
 */
 
 /* The block reward schedule is a migration from SAPP reward schedule. */
-    if (nPrevHeight < 18) {
+    if (nPrevHeight < 18)
+	{
         return 20000000 * COIN; // premine from SAPP (360M, burn the rest)
-    } else if (nPrevHeight < 20000) {
+    }
+	else if (nPrevHeight < 20000)
+	{
         nSubsidyBase = 2250;
-    } else if (nPrevHeight < 40000) {
+    }
+	else if (nPrevHeight < 40000)
+	{
         nSubsidyBase = 2000;
-    } else if (nPrevHeight < 60000) {
+    }
+	else if (nPrevHeight < 60000)
+	{
         nSubsidyBase = 1750;
-    } else if (nPrevHeight < 80000) {
+    }
+	else if (nPrevHeight < 80000)
+	{
         nSubsidyBase = 1500;
-    } else if (nPrevHeight < 100000) {
+    }
+	else if (nPrevHeight < 100000)
+	{
         nSubsidyBase = 1250;
-    } else if (nPrevHeight < 120000) {
+    }
+	else if (nPrevHeight < 120000)
+	{
         nSubsidyBase = 1125;
-    } else {
+    }
+	else
+	{
         nSubsidyBase = 1000;
     }
 
-    // if (nPrevHeight < 18) {
-    //     return 20000000 * COIN; // premine from SAPP (360M, burn the rest)
-    // } else if (nPrevHeight < 50001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 500) nSubsidyBase = 500;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 100001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 450) nSubsidyBase = 450;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 150001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 400) nSubsidyBase = 400;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 200001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 350) nSubsidyBase = 350;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 250001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 300) nSubsidyBase = 300;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 300001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 250) nSubsidyBase = 250;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else if (nPrevHeight < 350001) {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 225) nSubsidyBase = 225;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // } else {
-    //     nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-    //     if(nSubsidyBase > 200) nSubsidyBase = 200;
-    //     else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    // }
-
-
-    CAmount nSubsidy = nSubsidyBase * COIN;
-
-/* We do not use consensusParams.nSubsidyHalvingInterval for Kyanite coin but instead we use the reward schedule given above.
- ****************************************************************************************************************************
-    // yearly decline of production by ~7.1% per year, projected ~18M coins max by year 2050+.
-    for (int i = consensusParams.nSubsidyHalvingInterval; i <= nPrevHeight; i += consensusParams.nSubsidyHalvingInterval) {
-        nSubsidy -= nSubsidy/14;
-    }
-*/
-
-    // this is only active on devnets
-    if (nPrevHeight < consensusParams.nHighSubsidyBlocks) {
-        nSubsidy *= consensusParams.nHighSubsidyFactor;
-    }
-
-    // Hard fork to reduce the block reward by 10 extra percent (allowing budget/superblocks)
-    CAmount nSuperblockPart = (nPrevHeight > consensusParams.nBudgetPaymentsStartBlock) ? nSubsidy / 10 : 0;
-
-    return fSuperblockPartOnly ? nSuperblockPart : nSubsidy - nSuperblockPart;
+	return (nSubsidyBase * COIN) / (fSuperblockPartOnly ? 10 : 1);
 }
 
 CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
 {
-    CAmount ret = blockValue / 2; // Masternode payments for Kyanite will be 45% (50% of 90%) of the block reward.
+    CAmount ret = blockValue / 2; // Until block 80000 reached, masternode payments for Kyanite will be 50% of the block reward.
 
-    // int nMNPIBlock = Params().GetConsensus().nMasternodePaymentsIncreaseBlock;
-    // int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod;
+    int nMNPIBlock = Params().GetConsensus().nMasternodePaymentsIncreaseBlock; // Block 80000 - Approximately 2021-02-02 7:30  UTC
+    int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod; // 2016 blocks - 3.5 days
+	int rewardIncreasePercent = 8 / 100;
 
-/* DASH schedule
-                                                                      // mainnet:
-    if(nHeight > nMNPIBlock)                  ret += blockValue / 20; // 158000 - 25.0% - 2014-10-24
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 1)) ret += blockValue / 20; // 175280 - 30.0% - 2014-11-25
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 2)) ret += blockValue / 20; // 192560 - 35.0% - 2014-12-26
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 3)) ret += blockValue / 40; // 209840 - 37.5% - 2015-01-26
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 4)) ret += blockValue / 40; // 227120 - 40.0% - 2015-02-27
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 5)) ret += blockValue / 40; // 244400 - 42.5% - 2015-03-30
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 6)) ret += blockValue / 40; // 261680 - 45.0% - 2015-05-01
-    if(nHeight > nMNPIBlock+(nMNPIPeriod* 7)) ret += blockValue / 40; // 278960 - 47.5% - 2015-06-01
-*/
+	if (nHeight > nMNPIBlock + (nMNPIPeriod * 0)) ret += blockValue * 1 * rewardIncreasePercent; // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 1)) ret += blockValue * 2 * rewardIncreasePercent; // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 2)) ret += blockValue * 3 * rewardIncreasePercent; // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 3)) ret += blockValue * 4 * rewardIncreasePercent; // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 4)) ret += blockValue * 5 * rewardIncreasePercent; // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
 
    return ret;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1014,38 +1014,7 @@ CAmount GetBlockSubsidy(int nPrevBits, int nPrevHeight, const Consensus::Params&
     double dDiff;
     CAmount nSubsidyBase;
 
-/* This bug is irrelevant with Kyanite coin so commenting this out for now. It should be removed.
- ************************************************************************************************
-    if (nPrevHeight <= 4500 && Params().NetworkIDString() == CBaseChainParams::MAIN) {
-        // a bug which caused diff to not be correctly calculated
-        dDiff = (double)0x0000ffff / (double)(nPrevBits & 0x00ffffff);
-    } else {
-        dDiff = ConvertBitsToDouble(nPrevBits);
-    }
-*/
 	dDiff = ConvertBitsToDouble(nPrevBits);
-
-/*
-    if (nPrevHeight < 5465) {
-        // Early ages...
-        // 1111/((x+1)^2)
-        nSubsidyBase = (1111.0 / (pow((dDiff+1.0),2.0)));
-        if(nSubsidyBase > 500) nSubsidyBase = 500;
-        else if(nSubsidyBase < 1) nSubsidyBase = 1;
-    } else if (nPrevHeight < 17000 || (dDiff <= 75 && nPrevHeight < 24000)) {
-        // CPU mining era
-        // 11111/(((x+51)/6)^2)
-        nSubsidyBase = (11111.0 / (pow((dDiff+51.0)/6.0,2.0)));
-        if(nSubsidyBase > 500) nSubsidyBase = 500;
-        else if(nSubsidyBase < 25) nSubsidyBase = 25;
-    } else {
-        // GPU/ASIC mining era
-        // 2222222/(((x+2600)/9)^2)
-        nSubsidyBase = (2222222.0 / (pow((dDiff+2600.0)/9.0,2.0)));
-        if(nSubsidyBase > 25) nSubsidyBase = 25;
-        else if(nSubsidyBase < 5) nSubsidyBase = 5;
-    }
-*/
 
 /* The block reward schedule is a migration from SAPP reward schedule. */
     if (nPrevHeight < 18)
@@ -1092,11 +1061,11 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
     int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod; // 2016 blocks - 3.5 days
 	int rewardIncreasePercent = 8 / 100;
 
-	if (nHeight > nMNPIBlock + (nMNPIPeriod * 0)) ret += blockValue * 1 * rewardIncreasePercent; // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 1)) ret += blockValue * 2 * rewardIncreasePercent; // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 2)) ret += blockValue * 3 * rewardIncreasePercent; // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 3)) ret += blockValue * 4 * rewardIncreasePercent; // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
-    if (nHeight > nMNPIBlock + (nMNPIPeriod * 4)) ret += blockValue * 5 * rewardIncreasePercent; // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
+	if (nHeight > nMNPIBlock + (nMNPIPeriod * 0)) ret += blockValue * rewardIncreasePercent; // Block > 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 1)) ret += blockValue * rewardIncreasePercent; // Block > 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 2)) ret += blockValue * rewardIncreasePercent; // Block > 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 3)) ret += blockValue * rewardIncreasePercent; // Block > 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
+    if (nHeight > nMNPIBlock + (nMNPIPeriod * 4)) ret += blockValue * rewardIncreasePercent; // Block > 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
 
    return ret;
 }


### PR DESCRIPTION
This pull request changes the masternode reward share ratio gradually over a period of 17.5 days (10080 blocks)
Each step takes 2016 blocks (defined with Params().GetConsensus().nMasternodePaymentsIncreasePeriod in ```src/chainparams.cpp```) which takes 3.5 days.
At each step, reward share ratio increases 8% and the total increase will be 40% after 5 steps completed.

Increase process begins at block 80000 (Defined with Params().GetConsensus().nMasternodePaymentsIncreaseBlock in ```src/chainparams.cpp```)

Related function in ```src/validation.cpp``` is as follows:
```C++
CAmount GetMasternodePayment(int nHeight, CAmount blockValue)
{
    int nMNPIBlock = Params().GetConsensus().nMasternodePaymentsIncreaseBlock; // Block 80000 - Approximately 2021-02-02 7:30  UTC
    int nMNPIPeriod = Params().GetConsensus().nMasternodePaymentsIncreasePeriod; // 2016 blocks - 3.5 days

    if (nHeight < nMNPIBlock)
		return blockValue * (50 / 100); // Until block 80000 reached, masternode payments for Kyanite will be 50% of the block reward.

    if (nHeight < nMNPIBlock + (nMNPIPeriod * 1)) 
		return blockValue * (58 / 100); // Block: 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 

    if (nHeight < nMNPIBlock + (nMNPIPeriod * 2)) 
		return blockValue * (66 / 100); // Block: 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC

    if (nHeight < nMNPIBlock + (nMNPIPeriod * 3)) 
		return blockValue * (74 / 100); // Block: 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC

    if (nHeight < nMNPIBlock + (nMNPIPeriod * 4)) 
		return blockValue * (82 / 100); // Block: 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC

    return blockValue * (90 / 100); // Block: 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30	 UTC
}
```
**Step 1 starts:** Block: 80000 - Masternode share percent: 58.0% - Approximate date and time: 2021-02-02 7:30  UTC 
**Step 2 starts:** Block: 82016 - Masternode share percent: 66.0% - Approximate date and time: 2021-02-05 19:30 UTC
**Step 3 starts:** Block: 84032 - Masternode share percent: 74.0% - Approximate date and time: 2021-02-09 7:30  UTC
**Step 4 starts:** Block: 86048 - Masternode share percent: 82.0% - Approximate date and time: 2021-02-12 19:30 UTC
**Step 5 starts:** Block: 88066 - Masternode share percent: 90.0% - Approximate date and time: 2021-02-16 7:30 UTC

_**PS:** Value of block 80000 for the Params().GetConsensus().nMasternodePaymentsIncreaseBlock can change if needed._
