### PR TITLE
Enable masternode installation with IPv6

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -613,16 +613,9 @@ public:
         // nodes with support for servicebits filtering should be at the top
         vSeeds.emplace_back("kyan-testnet.572133.club", true);
         vSeeds.emplace_back("kyan-testnet2.572133.club", true);
-        vSeeds.emplace_back("seed1.sappcoin.com", true);
-        vSeeds.emplace_back("seed2.sappcoin.com", true);
-        vSeeds.emplace_back("seed3.sappcoin.com", true);
-        vSeeds.emplace_back("seed4.sappcoin.com", true);
-        vSeeds.emplace_back("seed5.sappcoin.com", true);
-        vSeeds.emplace_back("seed6.sappcoin.com", true);
-        vSeeds.emplace_back("seed7.sappcoin.com", true);
-        vSeeds.emplace_back("seed8.sappcoin.com", true);
-        vSeeds.emplace_back("seed9.sappcoin.com", true);
-        vSeeds.emplace_back("seed10.sappcoin.com", true);
+		vSeeds.emplace_back("testnet1.4444.tools", true);
+        vSeeds.emplace_back("testnet2.4444.tools", true);
+		
 
         // Testnet Kyan addresses start with 'k'
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,107);

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -36,7 +36,7 @@ static bool CheckService(const uint256& proTxHash, const ProTx& proTx, CValidati
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr-port");
     }
 
-    if (!proTx.addr.IsIPv4()) {
+    if (!proTx.addr.IsIPv4() && !proTx.addr.IsIPv6()) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr");
     }
 


### PR DESCRIPTION
This pull request enables masternode installation via IPv6.
The following two testnet masternodes are working on the same server and they are working right (masternodes gets rewards).

![image](https://user-images.githubusercontent.com/765487/114835924-c183be00-9dda-11eb-94bc-de5b6533c6c4.png)

To be able to setup the masternode with IPv6 alongside with IPv4, different RPC port should be given to each masternode as well as the bind option should be set in the configuration file with the IP (v4 or v6) and the default port of the network (7577 for mainnet and 7584 for testnet).

Example configs for IPv4 masternode and IPv6 masternode that run on the same server is as follows:
```
rpcuser=kyanuser111
rpcpassword=kyanpass111
rpcallowip=127.0.0.1
daemon=1
server=1
txindex=1
#debug=1
listen=1
#regtest=1

masternodeblsprivkey=6111e91c9876c8e3d2203c73d5e47a1e2a36eec016d1a439357534b3555ec486
bind=135.181.2.188:7584
externalip=135.181.2.188
```

```
rpcuser=kyanuser222
rpcpassword=kyanpass222
rpcallowip=127.0.0.1
rpcport=17585

daemon=1
server=1
txindex=1
listen=1
#debug=1
#regtest=1

masternodeblsprivkey=5f5a794f30317083843c11999b0d3e3b1b8e446c1269fdd4743fbbe235f7f531

bind=[2a01:4f9:4b:4f43::2]:7584
externalip=[2a01:4f9:4b:4f43::2]
```

If enabling IPv6 for the masternodes needs to be binded to a spork, It will be coded and tested next under this pull request.